### PR TITLE
smartcd edit and $EDITOR

### DIFF
--- a/lib/core/smartcd_edit
+++ b/lib/core/smartcd_edit
@@ -65,7 +65,7 @@ EOF
 ########################################################################
 EOF
         fi
-        ${EDITOR:-vi} "$tmpfile"
+        eval ${EDITOR:-vi} "$tmpfile"
         if [[ $? == 0 ]]; then
             echo -n > "$smartcd_dir/$file"
             if [[ -s "$tmpfile" ]]; then


### PR DESCRIPTION
Hi, I wasn't able to run command "smartcd edit" having EDITOR="emacs -nw", i.e. my $EDITOR is command, not path to executable.
So this was working with 'EDITOR="emacs" smardcd edit' and 'EDITOR="emacs -nw" smartcd template edit test', but in order to 'EDITOR="emacs -nw" smartcd edit' to work I have to apply this patch.
