### PR TITLE
Check $# before trying to shift off $@

### DIFF
--- a/lib/core/smartcd_template
+++ b/lib/core/smartcd_template
@@ -165,7 +165,7 @@ EOF
                     fi
                     ;;
                run) local name="$1"; shift
-                    local mode="$1"; shift
+                    local mode="$1"; [[ $# > 0 ]] && shift
                     if [[ -z $mode ]]; then
                         mode="$smartcd_runmode"
                     fi


### PR DESCRIPTION
In ZSH, if $@ is empty, a warning is issued when trying to
use `shift`. For instance:

```
zsh% shift
shift: shift count must be <= $#
```

The fix is simple, you just check $# beforehand and no
warning is issued:

```
zsh% [[ $# > 0 ]] && shift
```
