### PR TITLE
zsh compatible regex conditionals

### DIFF
--- a/lib/core/varstash
+++ b/lib/core/varstash
@@ -309,7 +309,11 @@ function unstash() {
         fi
         if [[ ( -n "$nostash" && -z "$unstashed" ) || ( -n "$unstashed" && -z "$unstashed_variable" ) ]]; then
             # Don't try to unset illegal variable names
-            if ! [[ $unstash_which =~ [^a-zA-Z0-9_] || $unstash_which =~ ^[0-9] ]]; then
+            if [[ $unstash_which =~ [^a-zA-Z0-9_] ]]; then 
+                false
+            elif [[ $unstash_which =~ ^[0-9] ]]; then
+                false
+            else
                 unset -v $unstash_which
             fi
         fi


### PR DESCRIPTION
I was having issues with smartcd under zsh, not unsetting
variables that were previously unset before being stashed.

For some reason, zsh doesn't like this type of construct:

    if ! [[ $cond1 || $cond2 ]]; then ...; fi

I played with it a bit and the only way I could get it
to work was to split it out into separate conditionals with
the action placed in the "else" clause.

This is a "works for me patch", feel free to implement in a
different way of course but this makes the unit tests pass under
ZSH for me.

Thanks!
