### PR TITLE
smartcd_export: fix endless loop with $fn becoming "/" always

### DIFF
--- a/lib/core/smartcd_export
+++ b/lib/core/smartcd_export
@@ -20,7 +20,8 @@ function smartcd_export() {
         # Skip directories never created
         if [[ -d "$base/$dir" ]]; then
             for entry in "$base/$dir/"*; do
-                local fn="${entry##*/}"
+                # Get filename, with trailing space from $entry removed (zsh).
+                local fn="${${entry%/}##*/}"
                 if [[ -f "$entry" ]]; then
                     echo "@ $dir/$fn"
                     local line=


### PR DESCRIPTION
This occurred with zsh 5.0.6-dev, which apparently adds a trailing slash
to the `"$base/$dir/"*` glob.
