### PR TITLE
export: set nullglob for zsh

### DIFF
--- a/lib/core/smartcd_export
+++ b/lib/core/smartcd_export
@@ -12,6 +12,7 @@ function smartcd_export() {
     local _old_ifs="$IFS"
     local base=$(_smartcd_base)
     IFS=$'\n'
+    [[ -n $ZSH_VERSION ]] && setopt localoptions && setopt nullglob
     echo "smartcd export 1.0"
     apush remaining_dirs "scripts" "templates"
     while (( $(alen remaining_dirs) > 0 )); do
@@ -30,7 +31,7 @@ function smartcd_export() {
                 elif [[ -d "$entry" ]]; then
                     apush remaining_dirs "$dir/$fn"
                 elif [[ "$entry" = "$base/$dir/*" ]]; then
-                    : # without nullglob the literal globbed string may appear; ignore it
+                    : # without nullglob (for bash) the literal globbed string may appear; ignore it
                 else
                     echo "Skipping unknown file $entry" >&2
                 fi


### PR DESCRIPTION
This fixes export for empty directories, where previously the following
error appeared:

> smartcd_export:12: no matches found: /home/user/.smartcd/scripts/foo/bar/*
