### PR TITLE
Replace usage of regex ("=~")

### DIFF
--- a/lib/core/varstash
+++ b/lib/core/varstash
@@ -82,7 +82,7 @@ function stash() {
 
 
     while [[ -n $1 ]]; do
-        if [[ $1 == "alias" && $2 =~ "=" ]]; then
+        if [[ $1 == "alias" && $2 == *=* ]]; then
             shift
             local _stashing_alias_assign=1
             continue
@@ -156,17 +156,17 @@ function stash() {
         local vartype="$(declare -p $stash_which 2>/dev/null)"
         if [[ -n $vartype ]]; then
             if [[ -n $ZSH_VERSION ]]; then
-                local pattern="^typeset"
+                local pattern="typeset"
             else
-                local pattern="^declare"
+                local pattern="declare"
             fi
-            if [[ $vartype =~ $pattern" -a" ]]; then
+            if [[ $vartype == $pattern" -a"* ]]; then
                 # varible is an array
                 if [[ -z $already_stashed ]]; then
                     eval "__varstash_array__$stash_name=(\"\${$stash_which""[@]}\")"
                 fi
 
-            elif [[ $vartype =~ $pattern" -x" ]]; then
+            elif [[ $vartype == $pattern" -x"* ]]; then
                 # variable is exported
                 if [[ -z $already_stashed ]]; then
                     eval "__varstash_export__$stash_name=\"\$$stash_which\""
@@ -222,7 +222,7 @@ function autostash() {
 
     local run_from_autostash=1
     while [[ -n $1 ]]; do
-        if [[ $1 == "alias" && $2 =~ "=" ]]; then
+        if [[ $1 == "alias" && $2 == *=* ]]; then
             shift
             local _stashing_alias_assign=1
         fi
@@ -311,7 +311,8 @@ function unstash() {
         fi
         if [[ ( -n "$nostash" && -z "$unstashed" ) || ( -n "$unstashed" && -z "$unstashed_variable" ) ]]; then
             # Don't try to unset illegal variable names
-            if ! [[ $unstash_which =~ [^a-zA-Z0-9_] || $unstash_which =~ ^[0-9] ]]; then
+            # Using substitution to avoid using regex, which might fail to load on Zsh (minimal system).
+            if [[ ${unstash_which//[^a-zA-Z0-9_]/} == $unstash_which && $unstash_which != [0-9]* ]]; then
                 unset -v $unstash_which
             fi
         fi


### PR DESCRIPTION
It's not really necessary and may cause problems on Zsh, when the regex
module cannot be loaded. This might happen on a minimal system.
