### PR TITLE
Fixed template creation when using ZSH

### DIFF
--- a/lib/core/smartcd_template
+++ b/lib/core/smartcd_template
@@ -32,7 +32,7 @@ function smartcd_template() {
 
                     command mkdir -p "$base/templates"
                     if [[ ! -f "$base/templates/$name" ]]; then
-                        command cat <<EOF >> "$base/templates/$name"
+                        command cat <<EOF > "$base/templates/$name"
 ########################################################################
 # This is a smartcd template.  Edit this file to create a named
 # configuration you can copy to any number of directories.  This is


### PR DESCRIPTION
Using ZSH, when I tried to create a new template, I got the following error:

> smartcd_template:34: no such file or directory: ~/.smartcd/templates/<template_name>

The editor then opened to let me create the actual template but it was empty (didn't contain the example content).
It was due to the use of the append operator `>>` to create the template. This operator doesn't create the file if it doesn't exist already unless the `CLOBBER` option is set (see [ZSH documentation](http://zsh.sourceforge.net/Doc/Release/Redirection.html)). As this instruction is wrapped in an `if` to make sure the file doesn't exist, using `>` instead seems safe enough.
