### PR TITLE
New helpers - append/prepend arbitrary variable

### DIFF
--- a/helper/append/completion
+++ b/helper/append/completion
@@ -1,4 +1,4 @@
-# $@ contains the command line after "smartcd helper run path"
+# $@ contains the command line after "smartcd helper run prepend"
 # $SMARTCD_COMP_CWORD contains the numbered argument which is currently being completed
 # Set words="" to what you want to suggest
 

--- a/helper/append/completion
+++ b/helper/append/completion
@@ -1,0 +1,7 @@
+# $@ contains the command line after "smartcd helper run path"
+# $SMARTCD_COMP_CWORD contains the numbered argument which is currently being completed
+# Set words="" to what you want to suggest
+
+case $SMARTCD_COMP_CWORD in
+    *) ;; # Path completion is the default
+esac

--- a/helper/append/meta
+++ b/helper/append/meta
@@ -1,0 +1,4 @@
+Description: Append a variable
+Author: Mark Swayne
+URI: https://raw.github.com/cxreg/smartcd/master/helper/append
+Version: 1.0

--- a/helper/append/script
+++ b/helper/append/script
@@ -1,0 +1,27 @@
+###############################################################################
+# Append values to any variable
+#
+# Example usage:
+#
+#     # append items to MYVAR variable
+#     local MYVAR='foo';
+#     smartcd helper run append MYVAR __PATH__/foo
+#     # $MYVAR='foo:__PATH__/foo'
+#
+###############################################################################
+
+local i
+local variable="$1"; shift
+local new
+for i in "$@"; do
+    if [[ -n "$new" ]]; then
+        new="$new:$i"
+    else
+        new="$i"
+    fi
+done
+if [[ -n "$new" ]]; then
+    eval autostash $variable="\"\$$variable:\$new\""
+else
+    eval autostash $variable="\"\$new\""
+fi

--- a/helper/prepend/completion
+++ b/helper/prepend/completion
@@ -1,4 +1,4 @@
-# $@ contains the command line after "smartcd helper run path"
+# $@ contains the command line after "smartcd helper run prepend"
 # $SMARTCD_COMP_CWORD contains the numbered argument which is currently being completed
 # Set words="" to what you want to suggest
 

--- a/helper/prepend/completion
+++ b/helper/prepend/completion
@@ -1,0 +1,7 @@
+# $@ contains the command line after "smartcd helper run path"
+# $SMARTCD_COMP_CWORD contains the numbered argument which is currently being completed
+# Set words="" to what you want to suggest
+
+case $SMARTCD_COMP_CWORD in
+    *) ;; # Path completion is the default
+esac

--- a/helper/prepend/meta
+++ b/helper/prepend/meta
@@ -1,0 +1,4 @@
+Description: Append a variable
+Author: Mark Swayne
+URI: https://raw.github.com/cxreg/smartcd/master/helper/append
+Version: 1.0

--- a/helper/prepend/meta
+++ b/helper/prepend/meta
@@ -1,4 +1,4 @@
-Description: Append a variable
+Description: Prepend a variable
 Author: Mark Swayne
 URI: https://raw.github.com/cxreg/smartcd/master/helper/append
 Version: 1.0

--- a/helper/prepend/script
+++ b/helper/prepend/script
@@ -1,0 +1,28 @@
+###############################################################################
+# Prepend values to any variable
+#
+# Example usage:
+#
+#     # append items to MYVAR variable
+#     local MYVAR='foo';
+#     smartcd helper run prepend MYVAR __PATH__/foo
+#     # $MYVAR='__PATH__/foo:foo'
+#
+###############################################################################
+
+local i
+local variable="$1"; shift
+local new
+
+for i in "$@"; do
+    if [[ -n "$new" ]]; then
+        new="$new:$i"
+    else
+        new="$i"
+    fi
+done
+if [[ -n "$new" ]]; then
+    eval autostash $variable="\"\$new:\$$variable\""
+else
+    eval autostash $variable="\"\$new\""
+    fi


### PR DESCRIPTION
New helpers work like path helper but for any variable.

These commands are equivalent:

    smartcd helper run append PATH /foo/bar/bin
    smartcd helper run path append /foo/bar/bin

    smartcd helper run prepend PATH /foo/bar/bin
    smartcd helper run path prepend /foo/bar/bin

