### PR TITLE
varstash: handle new output from `typeset -p` with Zsh 5.3

### DIFF
--- a/lib/core/varstash
+++ b/lib/core/varstash
@@ -166,7 +166,8 @@ function stash() {
                     eval "__varstash_array__$stash_name=(\"\${$stash_which""[@]}\")"
                 fi
 
-            elif [[ $vartype == $pattern" -x"* ]]; then
+            elif ([[ -n $ZSH_VERSION ]] && [[ $vartype == "export "* ]]) \
+                || [[ $vartype == $pattern" -x"* ]]; then
                 # variable is exported
                 if [[ -z $already_stashed ]]; then
                     eval "__varstash_export__$stash_name=\"\$$stash_which\""


### PR DESCRIPTION
Zsh 5.3 uses "export" instead of "typeset -x" for exported variables.
This was changed in zsh-5.2-566-g0f5e670cd.