### PR TITLE
varstash: export the variable for storing stashed vars

### DIFF
--- a/lib/core/varstash
+++ b/lib/core/varstash
@@ -169,7 +169,7 @@ function stash() {
             elif [[ $vartype == $pattern" -x"* ]]; then
                 # variable is exported
                 if [[ -z $already_stashed ]]; then
-                    eval "__varstash_export__$stash_name=\"\$$stash_which\""
+                    eval "export __varstash_export__$stash_name=\"\$$stash_which\""
                 fi
                 if [[ $stash_which != $stash_expression && -z $_stashing_alias_assign ]]; then
                     eval "export $stash_which=\"$stash_value\""
@@ -195,7 +195,7 @@ function stash() {
             # (eval):1: command not found: __varstash_nostash___tmp__home_dolszewski_src_smartcd_RANDOM_VARIABLE=1
             # fixed in zsh commit 724fd07a67f, version 4.3.14
             if [[ -z $already_stashed ]]; then
-                eval "__varstash_nostash__$stash_name=1"
+                eval "export __varstash_nostash__$stash_name=1"
             fi
 
             # In the case of a previously unset variable that we're assigning too, export it


### PR DESCRIPTION
Not sure if this is really smart, but I've added it a while back for zsh-autoenv (https://github.com/Tarrasch/zsh-autoenv/commit/c4e388980e44c339b4f1246e7b1f3ee6e3ac1b38).